### PR TITLE
fix: switch to `ffi-hunspell` since `hunspell-ffi` was depricated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
 *.rbc
+.tags
+tags
 .bundle
 .config
 .yardoc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Spelly
 
-This is a simple to use spell check gem that returns back the misspelled words and their common suggestions.  
+This is a simple to use spell check gem that returns back the misspelled words and their common suggestions.
+
+## Dependencies
+
+This gem depends on [Hunspell](http://hunspell.github.io/) lib.
+
+On **MacOS** it is being shipped as a part of the system from version 10.6 (Snow Leopard)
+
+On **Debian** (and derivatives) you might need to install Hunspell prior to this gem installation/usage:
+
+````shell
+sudo apt update
+sudo apt install hunspell
+````
 
 ## Installation
 
@@ -23,23 +36,49 @@ You can create the Spelly object by calling
     # passing in the language dictionary
     spelly = Spelly.new("en_US")
 
-A full list of dictionaries can be found here:
-http://wiki.openoffice.org/wiki/Dictionaries#English_.28AU.2CCA.2CGB.2CNZ.2CUS.2CZA.29
+The gem itself is shipped with `en_GB`, `en_US`, `pt_BR` and `pt_PT` dictionaries.
+
+For **additional dictionaries** see:
+[LibreOffice](http://cgit.freedesktop.org/libreoffice/dictionaries/tree/), [LibreOffice extensions](http://extensions.libreoffice.org/extensions?getCategories=Dictionary&getCompatibility=any&sort_on=positive_ratings&path=%2FLibreOffice-Extensions-and-Templates%2Fextension-center&portal_type=PSCProject&SearchableText=), [Mozilla Add-Ons](https://addons.mozilla.org/en-us/firefox/language-tools/) pages.
+
+To use additional dictionaries place them in one of the following dicrectories (**system dependant**):
+
+````shell
+# User installed dictionaries
+    ${HOME}/.hunspell_default
+
+# OS X brew-instlled hunspell
+    ${HOME}/Library/Spelling
+
+# Debian
+    /usr/local/share/myspell/dicts
+    /usr/share/myspell/dicts
+
+# Ubuntu
+    /usr/share/hunspell
+
+# Fedora
+    /usr/local/share/myspell
+    /usr/share/myspell
+
+# Mac Ports
+    /opt/local/share/hunspell
+    /opt/share/hunspell
+````
 
 Then you can run your spell check against an array of words by simply calling
 
     > spelly = Spelly.new("en_US")
     > words = %w/car bat yardd/
     > spelly.spell_check words
-    => [{:word=>"yardd", :suggest=>["yards", "yard", "yard d"]}] 
+    => [{:word=>"yardd", :suggest=>["yards", "yard", "yard d"]}]
 
 ## Contributing
 
 1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Test your changes (`bundle exec rspec`)
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create new Pull Request
 
-## TODO: 
-Add ability to allow end users to easily upload new dictionary files.

--- a/lib/spelly.rb
+++ b/lib/spelly.rb
@@ -1,23 +1,26 @@
 # frozen_string_literal: true
 
-require 'hunspell-ffi'
+require 'ffi/hunspell'
 
 class Spelly
   attr_accessor :dict
 
   def initialize(language)
     path = File.expand_path('../lib/dict', File.dirname(__FILE__))
-    # path = "#{Gem.loaded_specs['spelly'].full_gem_path}/lib/dict"
-    @dict = Hunspell.new(path, language)
+    FFI::Hunspell.directories = FFI::Hunspell.directories << path
+
+    @dict = FFI::Hunspell.dict(language)
   end
 
   def spell_check(words)
     results = []
+
     words.each do |word|
       unless @dict.check?(word)
         results << { word: word, suggest: @dict.suggest(word) }
       end
     end
+
     results
   end
 end

--- a/lib/spelly/version.rb
+++ b/lib/spelly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Spelly
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/spec/spelly_spec.rb
+++ b/spec/spelly_spec.rb
@@ -4,7 +4,7 @@ require_relative '../lib/spelly'
 
 describe Spelly do
   it 'should load a dictionary given en_US language' do
-    expect(Spelly.new('en_US').dict).to be_a_kind_of(Hunspell)
+    expect(Spelly.new('en_US').dict).to be_a_kind_of(FFI::Hunspell::Dictionary)
   end
 
   context '#spell_check en_GB' do
@@ -16,7 +16,7 @@ describe Spelly do
   end
 
   it 'should load a dictionary given pt_BR language' do
-    expect(Spelly.new('pt_BR').dict).to be_a_kind_of(Hunspell)
+    expect(Spelly.new('pt_BR').dict).to be_a_kind_of(FFI::Hunspell::Dictionary)
   end
 
   context '#spell_check pt_PT' do

--- a/spelly.gemspec
+++ b/spelly.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
-  gem.add_dependency 'hunspell-ffi'
+  gem.add_dependency 'ffi-hunspell'
   gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
doc: extensive README changes, including dictionary sources/installation
chore: add vim tags to .gitignore file
chore: version bump 0.0.2 → 0.0.3 (backward compatibility preserved)